### PR TITLE
fix set_pdb

### DIFF
--- a/ghidrecomp/utility.py
+++ b/ghidrecomp/utility.py
@@ -149,8 +149,8 @@ def set_pdb(program: "ghidra.program.model.listing.Program", path: Union[str, Pa
     from ghidra.app.plugin.core.analysis import PdbUniversalAnalyzer
     from java.io import File
 
-    print(f'Setting pdb to {symbol_path}')
     symbol_path = Path(path)
+    print(f'Setting pdb to {symbol_path}')
     pdbFile = File(symbol_path)
     PdbUniversalAnalyzer.setPdbFileOption(program, pdbFile)
 


### PR DESCRIPTION
symbol_path was printed before setting it, so this broke pyghidra-mcp when loading a pdb.

```
Traceback (most recent call last):
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 340, in _invoke_callbacks
    callback(self)                                                                                                                                                                                    ~~~~~~~~^^^^^^
  File "/home/ubuntu/.cache/uv/archive-v0/DQEsce4aT-mySsC55_4qr/lib/python3.13/site-packages/pyghidra_mcp/context.py", line 643, in _analysis_done_callback
    raise e
  File "/home/ubuntu/.cache/uv/archive-v0/DQEsce4aT-mySsC55_4qr/lib/python3.13/site-packages/pyghidra_mcp/context.py", line 639, in _analysis_done_callback
    future.result()
    ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ubuntu/.cache/uv/archive-v0/DQEsce4aT-mySsC55_4qr/lib/python3.13/site-packages/pyghidra_mcp/context.py", line 704, in _analyze_project
    result = future.result()
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ubuntu/.cache/uv/archive-v0/DQEsce4aT-mySsC55_4qr/lib/python3.13/site-packages/pyghidra_mcp/context.py", line 802, in analyze_program
    set_pdb(program, self.sym_file_path)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/archive-v0/DQEsce4aT-mySsC55_4qr/lib/python3.13/site-packages/ghidrecomp/utility.py", line 152, in set_pdb
    print(f'Setting pdb to {symbol_path}')
                            ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'symbol_path' where it is not associated with a value

```